### PR TITLE
We no longer need to filter for Herts libraries

### DIFF
--- a/render_data_as_html.py
+++ b/render_data_as_html.py
@@ -4,7 +4,6 @@ import collections
 import datetime
 import json
 import os
-import re
 import shutil
 
 import jinja2
@@ -12,36 +11,8 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from PIL import Image
 import titlecase
 
+from library_lookup.render_data_as_html import display_author_name
 from tint_colors import choose_tint_color_for_file, from_hex
-
-
-def display_author_name(label: str) -> str:
-    """
-    Convert an author name from Spydus into something to display
-    on the page.
-
-    See the tests for examples.
-    """
-    # Remove years of life from the end of the label, e.g.
-    #
-    #     Kawaguchi, Toshikazu, 1971-
-    #     Le Guin, Ursula K., 1929-2018
-    #
-    label = re.sub(r", [0-9]{4}\-(?:[0-9]{4})?$", "", label)
-
-    try:
-        last_name, first_name = label.split(",")
-    except ValueError:
-        return label
-
-    # Remove any trailing descriptions from the first name, e.g.
-    #
-    #     Claire (Journalist)
-    #     Justin (Comic book writer)
-    #
-    first_name = re.sub(r" \([A-Za-z ]+\)$", "", first_name)
-
-    return f"{first_name.strip()} {last_name.strip()}"
 
 
 def rgba(hs: str, opacity: float) -> str:

--- a/src/library_lookup/parsers.py
+++ b/src/library_lookup/parsers.py
@@ -43,13 +43,6 @@ def parse_availability_info(soup: bs4.BeautifulSoup) -> list[AvailabilityInfo]:
             {key: elem.text if elem else "" for key, elem in elements.items()},
         )
 
-        if "(Hertfordshire County Council)" not in info["location"]:
-            continue
-
-        info["location"] = info["location"].replace(
-            " (Hertfordshire County Council)", ""
-        )
-
         availability.append(info)
 
     return availability

--- a/src/library_lookup/render_data_as_html.py
+++ b/src/library_lookup/render_data_as_html.py
@@ -1,0 +1,30 @@
+import re
+
+
+def display_author_name(label: str) -> str:
+    """
+    Convert an author name from Spydus into something to display
+    on the page.
+
+    See the tests for examples.
+    """
+    # Remove years of life from the end of the label, e.g.
+    #
+    #     Kawaguchi, Toshikazu, 1971-
+    #     Le Guin, Ursula K., 1929-2018
+    #
+    label = re.sub(r", [0-9]{4}\-(?:[0-9]{4})?$", "", label)
+
+    try:
+        last_name, first_name = label.split(",")
+    except ValueError:
+        return label
+
+    # Remove any trailing descriptions from the first name, e.g.
+    #
+    #     Claire (Journalist)
+    #     Justin (Comic book writer)
+    #
+    first_name = re.sub(r" \([A-Za-z ]+\)$", "", first_name)
+
+    return f"{first_name.strip()} {last_name.strip()}"

--- a/tests/fixtures/availability.html
+++ b/tests/fixtures/availability.html
@@ -12,13 +12,13 @@
    </thead>
    <tbody>
       <tr>
-         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081170)&amp;QRYTEXT=St%20Albans%20Library">St Albans Library</a> (Hertfordshire County Council)</td>
+         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081170)&amp;QRYTEXT=St%20Albans%20Library">St Albans Library</a></td>
          <td data-caption="Collection"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?BIBCOLX=FIC*Fiction">Fiction</a></td>
          <td data-caption="Call number"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?CGF=SFP*Science%20fiction%20paperback">Science fiction paperback</a></td>
          <td data-caption="Status/Desc">Onloan - Due: 02 Jun 2024</td>
       </tr>
       <tr>
-         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081171)&amp;QRYTEXT=Stevenage%20Central%20Library">Stevenage Central Library</a> (Hertfordshire County Council)</td>
+         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081171)&amp;QRYTEXT=Stevenage%20Central%20Library">Stevenage Central Library</a></td>
          <td data-caption="Collection"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?BIBCOLX=FIC*Fiction">Fiction</a></td>
          <td data-caption="Call number"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?CGF=SFP*Science%20fiction%20paperback">Science fiction paperback</a></td>
          <td data-caption="Status/Desc">Available</td>
@@ -29,7 +29,7 @@
         value is missing
       -->
       <tr>
-         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256065150)&amp;QRYTEXT=Stony%20Stratford%20Library">Stony Stratford Library</a> (Milton Keynes Libraries)</td>
+         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256065150)&amp;QRYTEXT=Stony%20Stratford%20Library">Woodhall Library</a></td>
          <td data-caption="Collection"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?BIBCOLX=AFSF*Adult%20Fiction%3A%20Science%20Fiction%20%2F%20Fantasy%20Fiction">Adult Fiction: Science Fiction / Fantasy Fiction</a></td>
          <td></td>
          <td data-caption="Status/Desc">Available</td>

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -31,6 +31,12 @@ class TestParseAvailabilityInfo:
                 "status": "Available",
                 "call_number": "Science fiction paperback",
             },
+            {
+                "location": "Woodhall Library",
+                "collection": "Adult Fiction: Science Fiction / Fantasy Fiction",
+                "status": "Available",
+                "call_number": "",
+            },
         ]
 
 

--- a/tests/test_render_data_as_html.py
+++ b/tests/test_render_data_as_html.py
@@ -1,6 +1,6 @@
 import pytest
 
-from render_data_as_html import display_author_name
+from library_lookup.render_data_as_html import display_author_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Before: the `herts.spydus.co.uk` instance would show availability info from branches in multiple counties, including Herts and Bucks.  To tell them apart, each branch name would be shown with a suffix in parens, e.g.

    St Albans Library (Hertfordshire County Council)

The old code would filter to look for branches with the Herts suffix.

One of the changes in the Spydus upgrade is that `herts.spydus.co.uk` now only shows books from the Hertfordshire branches, which makes this filtering unnecessary.  But the filter was still being applied, so it would ignore everything.