### PR TITLE
Fix the lookup (again)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,6 +32,9 @@ jobs:
           ruff check .
           ruff format --check .
 
+      - name: Check docstrings
+        run: interrogate -vv
+
       - name: Check types
         run: mypy *.py src tests
 

--- a/render_data_as_html.py
+++ b/render_data_as_html.py
@@ -23,6 +23,15 @@ def rgba(hs: str, opacity: float) -> str:
 if __name__ == "__main__":
     book_data = json.load(open("books.json"))
 
+    for book in book_data["books"]:
+        for av in list(book["availability"]):
+            if av["location"].endswith(" (Hertfordshire Libraries)"):
+                av["location"] = av["location"].replace(
+                    " (Hertfordshire Libraries)", ""
+                )
+            else:
+                book["availability"].remove(av)
+
     # Group books by (title, author) pairs.  This ensures that copies
     # of the same book in different formats (e.g. paperback, hardback)
     # will be collapsed into a single entry.

--- a/src/library_lookup/parsers.py
+++ b/src/library_lookup/parsers.py
@@ -43,13 +43,6 @@ def parse_availability_info(soup: bs4.BeautifulSoup) -> list[AvailabilityInfo]:
             {key: elem.text if elem else "" for key, elem in elements.items()},
         )
 
-        if "(Hertfordshire County Council)" not in info["location"]:
-            continue
-
-        info["location"] = info["location"].replace(
-            " (Hertfordshire County Council)", ""
-        )
-
         availability.append(info)
 
     return availability

--- a/tests/fixtures/availability.html
+++ b/tests/fixtures/availability.html
@@ -12,13 +12,13 @@
    </thead>
    <tbody>
       <tr>
-         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081170)&amp;QRYTEXT=St%20Albans%20Library">St Albans Library</a> (Hertfordshire County Council)</td>
+         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081170)&amp;QRYTEXT=St%20Albans%20Library">St Albans Library</a></td>
          <td data-caption="Collection"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?BIBCOLX=FIC*Fiction">Fiction</a></td>
          <td data-caption="Call number"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?CGF=SFP*Science%20fiction%20paperback">Science fiction paperback</a></td>
          <td data-caption="Status/Desc">Onloan - Due: 02 Jun 2024</td>
       </tr>
       <tr>
-         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081171)&amp;QRYTEXT=Stevenage%20Central%20Library">Stevenage Central Library</a> (Hertfordshire County Council)</td>
+         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256081171)&amp;QRYTEXT=Stevenage%20Central%20Library">Stevenage Central Library</a></td>
          <td data-caption="Collection"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?BIBCOLX=FIC*Fiction">Fiction</a></td>
          <td data-caption="Call number"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?CGF=SFP*Science%20fiction%20paperback">Science fiction paperback</a></td>
          <td data-caption="Status/Desc">Available</td>
@@ -29,7 +29,7 @@
         value is missing
       -->
       <tr>
-         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256065150)&amp;QRYTEXT=Stony%20Stratford%20Library">Stony Stratford Library</a> (Milton Keynes Libraries)</td>
+         <td data-caption="Location"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/GENENQ/285096?QRY=IRN(256065150)&amp;QRYTEXT=Stony%20Stratford%20Library">Woodhall Library</a></td>
          <td data-caption="Collection"><a href="/cgi-bin/spydus.exe/ENQ/WPAC/BIBENQ/285096?BIBCOLX=AFSF*Adult%20Fiction%3A%20Science%20Fiction%20%2F%20Fantasy%20Fiction">Adult Fiction: Science Fiction / Fantasy Fiction</a></td>
          <td></td>
          <td data-caption="Status/Desc">Available</td>

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -31,6 +31,12 @@ class TestParseAvailabilityInfo:
                 "status": "Available",
                 "call_number": "Science fiction paperback",
             },
+            {
+                "location": "Woodhall Library",
+                "collection": "Adult Fiction: Science Fiction / Fantasy Fiction",
+                "status": "Available",
+                "call_number": "",
+            },
         ]
 
 


### PR DESCRIPTION
The library have been updating their website recently, and this tool broke. I tried to fix it, but I was building against a work-in-progress site – because they deployed another “fix” that broke my initial fix. Chaos!

This should fix the tool to work with the current version of the site.

I’ve also changed how the filtering works – previously I was filtering availability data before I saved it, which is frustrating when it filters out everything! So now it saves all the availability data, and just filters when it renders the page.